### PR TITLE
A bug fix for crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/venv


### PR DESCRIPTION
* Discovery.py crash issue:
It is crashed when Apache Flink is launching and not responding.
It is caused by returning None for dictionary update ({}.update(None)).

* Apache Flink selection:
It is searching Apache Flink jobs only, but it has a bug to find all kinds of jobs.